### PR TITLE
:lipstick: (adminProfile): STYLE: 관리 프로필 공통 컴포넌트 속성 변경

### DIFF
--- a/src/components/units/admin/profile/adminProfile.presenter.tsx
+++ b/src/components/units/admin/profile/adminProfile.presenter.tsx
@@ -41,16 +41,17 @@ const AdminProfileUI = (props: IAdminProfileProps) => {
           <S.FormContents>
             <S.Label>직무들</S.Label>
             <Select01
-              register={props.register('duty')}
+              register={props.register}
               setValue={props.setValue}
+              fieldName={'duty'}
             />
           </S.FormContents>
           <S.FormContents>
-            <S.Label>팀</S.Label>
+            <S.Label>지점들</S.Label>
             <Select01
-              center
-              register={props.register('organization')}
+              register={props.register}
               setValue={props.setValue}
+              fieldName={'oranization'}
               data={['BUSKER', 'ZERO9', 'WETREKKING'] || undefined}
             />
           </S.FormContents>


### PR DESCRIPTION
공통 컴포넌트 Select01의 사용법이 바뀐 후에 그에 맞는 최신화를 해주지 않아서 관리자 페이지의 프로필 탭이 들어가지지 않던 버그 픽스

추가로, 두 번째 공통 컴포넌트 위치 중앙 정렬되어 있던 것 다시 좌측 정렬로 변경

closed #104