### PR TITLE
:recycle: (adminManage): REF: 어드민 관리 리팩토링

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -3,9 +3,11 @@ import { useEffect } from 'react';
 
 const AdminPage = () => {
   const router = useRouter();
+
   useEffect(() => {
-    router.push('/admin/home');
-  }, []);
+    void router.push('/admin/home');
+  });
+
   return <div>안녕해새요~ 어떻게 들어오션나용</div>;
 };
 

--- a/src/components/commons/apollo/index.tsx
+++ b/src/components/commons/apollo/index.tsx
@@ -17,7 +17,8 @@ interface IApolloSettingProps {
 }
 
 export default function ApolloSetting(props: IApolloSettingProps) {
-  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+  const [accessToken, setAccessToken] =
+    useRecoilState<string>(accessTokenState);
 
   useEffect(() => {
     void getAccessToken().then((newAccessToken: string) => {

--- a/src/components/commons/input/select01.tsx
+++ b/src/components/commons/input/select01.tsx
@@ -31,7 +31,7 @@ interface ISelectProps {
   textFillMode?: boolean;
 }
 
-interface InputData {
+export interface InputData {
   id: string;
   name: string;
 }
@@ -43,6 +43,7 @@ interface IStyle {
 }
 
 const Select01 = (props: ISelectProps) => {
+  if (props.setState) props.register = undefined;
   const [isOpen, setIsOpen] = useState(false);
   const [saveChecked, setSaveChecked] = useState<InputData[]>(
     props.defaultChecked && props.defaultChecked.length > 0
@@ -54,6 +55,7 @@ const Select01 = (props: ISelectProps) => {
       ? props.defaultChecked
       : [],
   );
+
   const [keyword, setKeyword] = useState('');
 
   const onCheckedAll = useCallback(
@@ -68,9 +70,9 @@ const Select01 = (props: ISelectProps) => {
   );
 
   const onCheckedElement = useCallback(
-    (checked, list) => {
-      if (checked) setCheckedList([...checkedList, list]);
-      else setCheckedList(checkedList.filter((el) => el !== list));
+    (checked, selectedTarget) => {
+      if (checked) setCheckedList([...checkedList, selectedTarget]);
+      else setCheckedList(checkedList.filter((el) => el !== selectedTarget));
     },
     [checkedList],
   );
@@ -100,13 +102,17 @@ const Select01 = (props: ISelectProps) => {
   };
 
   const onClickSaveChecked = () => {
-    if (props.name === undefined) {
-      throw Error('props.name의 값이 undefined 입니다.');
-    }
+    if (props.setState === undefined) {
+      if (props.name === undefined) {
+        throw Error('name 속성이 선언되지 않았습니다.');
+      }
+      if (props.setValue === undefined) {
+        throw Error('setValue 속성이 선언되지 않았습니다.');
+      }
+      props.setValue?.(props.name, checkedList);
+    } else props.setState?.(checkedList);
     setSaveChecked(checkedList);
-    props.setValue?.(props.name, checkedList);
     setIsOpen(false);
-    props.setState?.(checkedList);
   };
 
   return (
@@ -170,7 +176,11 @@ const Select01 = (props: ISelectProps) => {
                         <Check01
                           key={el.id}
                           text={el.name}
-                          checked={checkedList.includes(el)}
+                          checked={
+                            checkedList.filter(
+                              (listItem) => listItem.id === el.id,
+                            ).length > 0
+                          }
                           onChange={(event) =>
                             onCheckedElement(event.target.checked, el)
                           }

--- a/src/components/commons/inputLabel.tsx
+++ b/src/components/commons/inputLabel.tsx
@@ -5,7 +5,7 @@ import {
   UseFormSetValue,
 } from 'react-hook-form';
 import Input01 from './input/input01';
-import Select01 from './input/select01';
+import Select01, { InputData } from './input/select01';
 import Label from '../units/admin/manage/forms/common/label';
 
 interface IInputLabelProps {
@@ -13,7 +13,7 @@ interface IInputLabelProps {
   type: string;
   name: string;
   register?: UseFormRegisterReturn;
-  data?: string[];
+  data?: InputData[];
   setValue?: UseFormSetValue<FieldValues>;
   defaultChecked?: any[];
   textFillMode?: boolean;
@@ -59,4 +59,8 @@ const FormContent = styled.div`
   display: flex;
   align-items: center;
   gap: 2rem;
+
+  input[type='color'] {
+    padding: 0;
+  }
 `;

--- a/src/components/commons/modal/fallingModal.tsx
+++ b/src/components/commons/modal/fallingModal.tsx
@@ -101,10 +101,12 @@ const Wrapper = styled.div`
 const CustomModal = styled.div`
   position: relative;
   top: 2rem;
+  max-width: 90%;
   height: fit-content;
   background-color: white;
 
-  min-width: ${(props: IStyle) => props.width};
+  max-width: ${(props: IStyle) => props.width};
+
   opacity: 0;
   animation: ${(props: IStyle) =>
     props.aniMode

--- a/src/components/units/admin/manage/forms/attendanceLocation.tsx
+++ b/src/components/units/admin/manage/forms/attendanceLocation.tsx
@@ -1,14 +1,15 @@
 import { WifiOutlined } from '@ant-design/icons';
 import styled from '@emotion/styled';
 import axios from 'axios';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { styleSet } from '../../../../../commons/styles/styleSet';
 import Check01 from '../../../../commons/input/check01';
 import Input01 from '../../../../commons/input/input01';
-import Textarea from '../../../../commons/textarea';
 import Footer from './common/footer';
 import Label from './common/label';
 import { IFormProps } from './common/form.types';
+import InputLabel from '../../../../commons/inputLabel';
+import Memo from './common/memo';
 
 // API 키값 env로 ??
 const API_KEY = '726352a79674495788faaade6bbbb04d';
@@ -16,36 +17,40 @@ const API_KEY = '726352a79674495788faaade6bbbb04d';
 const AttendanceLocation = (props: IFormProps) => {
   const [positionTab, setPositionTab] = useState(false);
   const [wifiTab, setWifiTab] = useState(false);
+  const [ip, setIp] = useState('');
 
-  const getMyIp = async () => {
+  useEffect(() => {
     const getIp = async () => {
       await axios
         .get(`https://ipgeolocation.abstractapi.com/v1/?api_key=${API_KEY}`)
-        .then((res) => props.setValue?.('ip', res.data.ip_address));
+        .then((res) => setIp(res.data.ip_address));
     };
-    await getIp();
-  };
+    void getIp();
+  }, []);
+
+  const { setValue } = props;
+
+  const paintIp = useCallback(() => {
+    setValue?.('ip', ip);
+  }, [ip, setValue]);
+
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
-        <FormContent>
-          <Label for="name">출퇴근 장소명</Label>
-          <Input01
-            register={props.register('name')}
-            width="10rem"
-            type="text"
-            id="name"
-          />
-        </FormContent>
-        <FormContent>
-          <Label for="address">근무지 주소</Label>
-          <Input01
-            register={props.register('address')}
-            width="10rem"
-            type="text"
-            id="address"
-          />
-        </FormContent>
+        <InputLabel
+          register={props.register('name')}
+          type="text"
+          name="attendanceLocationName"
+        >
+          출퇴근 장소명
+        </InputLabel>
+        <InputLabel
+          register={props.register('address')}
+          type="text"
+          name="workAddress"
+        >
+          근무지 주소
+        </InputLabel>
         <FormContent>
           <Label for="method">출퇴근 수단</Label>
           <CheckBoxWrapper>
@@ -56,7 +61,6 @@ const AttendanceLocation = (props: IFormProps) => {
             <Check01 text="WiFi" onChange={() => setWifiTab((prev) => !prev)} />
           </CheckBoxWrapper>
         </FormContent>
-
         {positionTab && (
           <ConditionalTab>
             <FormContent>
@@ -72,13 +76,12 @@ const AttendanceLocation = (props: IFormProps) => {
             </KakaoMapWrapper>
           </ConditionalTab>
         )}
-
         {wifiTab && (
           <ConditionalTab>
             <FormContent style={{ flexDirection: 'row', alignItems: 'center' }}>
               <Label for="wifi">WiFi IP주소</Label>
               <WifiBox>
-                <WifiButton type="button" onClick={getMyIp}>
+                <WifiButton type="button" onClick={paintIp}>
                   <WifiOutlined />
                 </WifiButton>
                 <Input01
@@ -91,14 +94,7 @@ const AttendanceLocation = (props: IFormProps) => {
             </FormContent>
           </ConditionalTab>
         )}
-
-        <FormContent>
-          <Label for="memo">메모</Label>
-          <Textarea
-            register={props.register('memo')}
-            placeholder="메모 입력"
-          ></Textarea>
-        </FormContent>
+        <Memo register={props.register('memo')} />
       </Wrapper>
       <Footer onCancel={props.onCancel} />
     </form>

--- a/src/components/units/admin/manage/forms/common/memo.tsx
+++ b/src/components/units/admin/manage/forms/common/memo.tsx
@@ -27,6 +27,7 @@ const Memo = (props: IMemoProps) => {
 export default Memo;
 
 const MemoWrapper = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/components/units/admin/manage/forms/duty.tsx
+++ b/src/components/units/admin/manage/forms/duty.tsx
@@ -1,36 +1,30 @@
 import styled from '@emotion/styled';
-import { Divider } from 'antd';
-import Input01 from '../../../../commons/input/input01';
-import Textarea from '../../../../commons/textarea';
+import InputLabel from '../../../../commons/inputLabel';
 import Footer from './common/footer';
 import { IFormProps } from './common/form.types';
+import Memo from './common/memo';
 
 const Duty = (props: IFormProps) => {
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
-        <FormContent>
-          <label htmlFor="duty">직무명</label>
-          <Input01
-            id="duty"
-            type="text"
-            register={props.register('duty_name')}
-          />
-        </FormContent>
-        <FormContent>
-          <label htmlFor="color">색깔</label>{' '}
-          <ColorPicker
-            id="color"
-            type="color"
-            {...props.register('duty_color')}
-          />
-        </FormContent>
-        <FormContent>
-          <label htmlFor="memo">메모</label>
-          <Textarea id="memo" register={props.register('duty_memo')} />
-        </FormContent>
+        <InputLabel
+          name="duty_name"
+          type="text"
+          register={props.register('duty_name')}
+        >
+          직무명
+        </InputLabel>
+        <InputLabel
+          name="duty_color"
+          type="color"
+          register={props.register('duty_color')}
+          inputWidth="1.5rem"
+        >
+          색깔
+        </InputLabel>
+        <Memo register={props.register('memo')} />
       </Wrapper>
-      <Divider style={{ marginBottom: '0.5rem' }} />
       <Footer onCancel={props.onCancel} />
     </form>
   );
@@ -40,26 +34,7 @@ export default Duty;
 
 const Wrapper = styled.div`
   width: 31.5rem;
-
   display: flex;
   flex-direction: column;
   gap: 1rem;
 `;
-
-const FormContent = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 1rem;
-
-  & > label {
-    min-width: 5rem;
-  }
-
-  :last-of-type {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-`;
-
-const ColorPicker = styled.input``;

--- a/src/components/units/admin/manage/forms/leaveTypes.tsx
+++ b/src/components/units/admin/manage/forms/leaveTypes.tsx
@@ -17,7 +17,10 @@ const LeaveTypes = (props: IFormProps) => {
           이름
         </InputLabel>
         <InputLabel
-          data={['패파', '우리집']}
+          data={[
+            { id: '123', name: '패파' },
+            { id: '1234', name: '패파' },
+          ]}
           register={props.register('organization')}
           setValue={props.setValue}
           type="select"
@@ -27,7 +30,10 @@ const LeaveTypes = (props: IFormProps) => {
           지점
         </InputLabel>
         <InputLabel
-          data={['프론트엔드', '백엔드']}
+          data={[
+            { id: '1', name: '프론트엔드' },
+            { id: '12', name: '백엔드' },
+          ]}
           register={props.register('duty')}
           setValue={props.setValue}
           type="select"

--- a/src/components/units/admin/manage/forms/member.tsx
+++ b/src/components/units/admin/manage/forms/member.tsx
@@ -1,74 +1,163 @@
 import styled from '@emotion/styled';
 import { DatePicker, Divider } from 'antd';
+import type { DatePickerProps } from 'antd';
+import { useState } from 'react';
 import { styleSet } from '../../../../../commons/styles/styleSet';
 import Check01 from '../../../../commons/input/check01';
-import Input01 from '../../../../commons/input/input01';
-import Select01 from '../../../../commons/input/select01';
+import InputLabel from '../../../../commons/inputLabel';
 import Footer from './common/footer';
 import { IFormProps } from './common/form.types';
+import { Dayjs } from 'dayjs';
+import Memo from './common/memo';
 
 const MemberForm = (props: IFormProps) => {
+  const invitationArray = ['전송 안함', '즉시 전송', '예약 전송'];
+
+  const [invitationRadio, setInvitationRadio] = useState([true, false, false]);
+  const [isActiveStartDate, setIsActiveStartDate] = useState(false);
+  const [isActiveEndDate, setIsActiveEndDate] = useState(false);
+  const [isActiveWagesInput, setIsActiveWagesInput] = useState(false);
+
+  const onChangeStartDate: DatePickerProps['onChange'] = (
+    date: Dayjs | null,
+  ) => {
+    props.setValue?.('startDate', new Date(String(date?.format('YYYY-MM-DD'))));
+  };
+  const onChangeEndDate: DatePickerProps['onChange'] = (date: Dayjs | null) => {
+    props.setValue?.('endDate', new Date(String(date?.format('YYYY-MM-DD'))));
+  };
+  const onChangeApplyFrom: DatePickerProps['onChange'] = (
+    date: Dayjs | null,
+  ) => {
+    props.setValue?.('applyFrom', new Date(String(date?.format('YYYY-MM-DD'))));
+  };
+
+  const onChangeInvitation = (index: number) => () => {
+    setInvitationRadio(invitationRadio.map((_, i) => index === i));
+  };
+
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <WrapperM>
         <Left>
           <div>
             <h3>직원정보</h3>
-            <FormContent>
-              <Label>이름</Label>
-              <Input01
-                width="250px"
+            <FormWrapper>
+              <InputLabel
                 type="text"
+                name="name"
                 register={props.register('name')}
-              />
-            </FormContent>
-            <FormContent>
-              <Label>액세스 권한</Label>
-              <Select01 name="accessAuth" />
-            </FormContent>
-            <FormContent>
-              <Label>직무들</Label>
-              <Select01 name="duty" />
-            </FormContent>
-            <FormContent>
-              <Label>팀들</Label>
-              <Select01 name="organization" />
-            </FormContent>
-            <FormContent>
-              <InnerContent>
-                <Check01 text="입사일" />
-                <DatePicker />
-              </InnerContent>
-              <InnerContent>
-                <Check01 text="퇴사일" />
-                <DatePicker />
-              </InnerContent>
-            </FormContent>
+              >
+                이름
+              </InputLabel>
+              <InputLabel
+                type="select"
+                name="duty"
+                setValue={props.setValue}
+                register={props.register('duty')}
+              >
+                직무들
+              </InputLabel>
+              <InputLabel
+                type="select"
+                name="organization"
+                setValue={props.setValue}
+                register={props.register('organization')}
+              >
+                지점들
+              </InputLabel>
+              <FormContent>
+                <InnerContent>
+                  <Check01
+                    onChange={() => setIsActiveStartDate((prev) => !prev)}
+                    text="입사일"
+                  />
+                  {isActiveStartDate && (
+                    <DatePicker
+                      onChange={onChangeStartDate}
+                      style={{ flex: '2' }}
+                    />
+                  )}
+                </InnerContent>
+                <InnerContent>
+                  <Check01
+                    onChange={() => setIsActiveEndDate((prev) => !prev)}
+                    text="퇴사일"
+                  />
+                  {isActiveEndDate && (
+                    <DatePicker
+                      onChange={onChangeEndDate}
+                      style={{ flex: '2' }}
+                    />
+                  )}
+                </InnerContent>
+              </FormContent>
+            </FormWrapper>
           </div>
           <div>
             <h3>직원합류 초대</h3>
-            <FormContent>
-              <Check01 text="전송 안함" />
-              <Check01 text="즉시 전송" />
-              <Check01 text="예약 전송" />
-            </FormContent>
-            <Divider />
-            메모
-            <Input01 type="text" register={props.register('memo')} />
+            <FormWrapper>
+              <FormContent>
+                {invitationArray.map((content, index) => (
+                  <Check01
+                    key={index}
+                    text={content}
+                    onChange={onChangeInvitation(index)}
+                    checked={invitationRadio[index]}
+                  />
+                ))}
+              </FormContent>
+              {invitationRadio[1] && (
+                <>
+                  <InputLabel
+                    type="text"
+                    name="email"
+                    setValue={props.setValue}
+                    register={props.register('email')}
+                  >
+                    이메일
+                  </InputLabel>
+                  <p style={{ lineHeight: '1.5rem' }}>
+                    합류코드가 각 직원에 등록된 이메일 및 전화번호로 즉시
+                    전송됩니다.
+                    <br /> 이메일 또는 전화번호를 입력하지 않은 경우, 합류코드를
+                    전송할 수 없습니다.
+                  </p>
+                </>
+              )}
+              <CustomDivider />
+              <Memo register={props.register('memo')} />
+            </FormWrapper>
           </div>
         </Left>
         <Right>
           <div>
             <h3>근로정보</h3>
-            <FormContent>
-              <Check01 text="근로 정보 입력" />
-            </FormContent>
-          </div>
-          <div>
-            <h3>휴가 발생</h3>
-            <FormContent>
-              <Check01 text="규칙 기반 휴가 자동 발생 입력" />
-            </FormContent>
+            <FormWrapper>
+              <Check01
+                onChange={() => setIsActiveWagesInput((prev) => !prev)}
+                text="근로 정보 입력"
+              />
+              {isActiveWagesInput && (
+                <>
+                  <InputLabel
+                    type="select"
+                    name="wages"
+                    setValue={props.setValue}
+                    register={props.register('wages')}
+                  >
+                    근로정보
+                  </InputLabel>
+                  <InputLabel
+                    type="custom"
+                    name="applyFrom"
+                    customInput={<DatePicker onChange={onChangeApplyFrom} />}
+                  >
+                    적용 시점
+                  </InputLabel>
+                </>
+              )}
+            </FormWrapper>
           </div>
         </Right>
       </WrapperM>
@@ -80,7 +169,7 @@ const MemberForm = (props: IFormProps) => {
 export default MemberForm;
 
 const WrapperM = styled.div`
-  width: 1100px;
+  min-width: 1100px;
   display: flex;
   flex-direction: row;
   gap: 2rem;
@@ -93,6 +182,8 @@ const WrapperM = styled.div`
   }
 
   @media (max-width: 1200px) {
+    min-width: auto;
+    width: 100%;
     flex-direction: column;
   }
 `;
@@ -104,19 +195,27 @@ const Right = styled.div`
   flex: 2;
 `;
 
+const FormWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+`;
+
 const FormContent = styled.div`
-  padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 1rem;
 `;
 
 const InnerContent = styled.div`
   min-width: 18rem;
+  height: 2rem;
   display: flex;
   gap: 1rem;
 `;
 
-const Label = styled.label`
-  min-width: 120px;
+const CustomDivider = styled(Divider)`
+  margin: 0;
 `;

--- a/src/components/units/admin/manage/forms/oranization.tsx
+++ b/src/components/units/admin/manage/forms/oranization.tsx
@@ -1,37 +1,33 @@
 import styled from '@emotion/styled';
-import Input01 from '../../../../commons/input/input01';
-import Select01 from '../../../../commons/input/select01';
+import InputLabel from '../../../../commons/inputLabel';
 import Footer from './common/footer';
 import { IFormProps } from './common/form.types';
+import Memo from './common/memo';
 
 const OrganizationForm = (props: IFormProps) => {
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
-        <FormContent>
-          <span>지점명</span>
-          <Input01
-            type="text"
-            width="180px"
-            register={props.register('organization')}
-          />
-        </FormContent>
-        <FormContent>
-          <span>출퇴근 장소들</span>
-          <Select01
-            name="location"
-            setValue={props.setValue}
-            register={props.register('location')}
-            data={['패파', '희현님집']}
-          />
-        </FormContent>
-        <FormContent>
-          <span>메모</span>
-          <Textarea
-            placeholder="메모 입력"
-            {...props.register('memo')}
-          ></Textarea>
-        </FormContent>
+        <InputLabel
+          type="text"
+          name="organization"
+          register={props.register('organization')}
+        >
+          지점명
+        </InputLabel>
+        <InputLabel
+          type="select"
+          name="location"
+          setValue={props.setValue}
+          register={props.register('location')}
+          data={[
+            { id: '123', name: '패파' },
+            { id: '1234', name: '패파' },
+          ]}
+        >
+          출퇴근 장소들
+        </InputLabel>
+        <Memo register={props.register('memo')} />
       </Wrapper>
       <Footer onCancel={props.onCancel} />
     </form>
@@ -45,26 +41,4 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-`;
-
-const FormContent = styled.div`
-  display: flex;
-  align-items: center;
-  & > span {
-    min-width: 100px;
-  }
-
-  :nth-of-type(3) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  gap: 1rem;
-`;
-
-const Textarea = styled.textarea`
-  resize: none;
-  width: 100%;
-  height: 100px;
-  padding: 1rem;
-  outline: none;
 `;

--- a/src/components/units/admin/manage/forms/shiftTemplate.tsx
+++ b/src/components/units/admin/manage/forms/shiftTemplate.tsx
@@ -8,7 +8,6 @@ import Memo from './common/memo';
 const { RangePicker } = TimePicker;
 
 const ShiftTemplate = (props: IFormProps) => {
-  const format = 'HH:mm';
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
@@ -22,12 +21,23 @@ const ShiftTemplate = (props: IFormProps) => {
         <InputLabel
           type="custom"
           name="time"
-          customInput={<RangePicker format={format} />}
+          customInput={
+            <RangePicker
+              onChange={(data: any) => {
+                props.setValue?.('startTime', data?.[0]?.$d);
+                props.setValue?.('endTime', data?.[1]?.$d);
+              }}
+              format={'HH:mm'}
+            />
+          }
         >
           시간
         </InputLabel>
         <InputLabel
-          data={['오전 근무', '야간 근무']}
+          data={[
+            { id: '오전 근무', name: '오전 근무' },
+            { id: '야간 근무', name: '야간 근무' },
+          ]}
           register={props.register('shiftTypes')}
           setValue={props.setValue}
           type="select"
@@ -36,7 +46,10 @@ const ShiftTemplate = (props: IFormProps) => {
           근무일정 유형
         </InputLabel>
         <InputLabel
-          data={['패스트 파이브', '영등포구청']}
+          data={[
+            { id: '패스트 파이브', name: '패스트 파이브' },
+            { id: '영등포구청', name: '영등포구청' },
+          ]}
           register={props.register('organization')}
           setValue={props.setValue}
           type="select"
@@ -45,7 +58,10 @@ const ShiftTemplate = (props: IFormProps) => {
           지점
         </InputLabel>
         <InputLabel
-          data={['프론트엔드', '백엔드']}
+          data={[
+            { id: '프론트엔드', name: '프론트엔드' },
+            { id: '백엔드', name: '백엔드' },
+          ]}
           register={props.register('duty')}
           setValue={props.setValue}
           type="select"

--- a/src/components/units/admin/manage/forms/shiftTypes.tsx
+++ b/src/components/units/admin/manage/forms/shiftTypes.tsx
@@ -50,8 +50,4 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-
-  input[type='color'] {
-    padding: 0;
-  }
 `;

--- a/src/components/units/admin/manage/forms/wages/basicInfo.tsx
+++ b/src/components/units/admin/manage/forms/wages/basicInfo.tsx
@@ -24,9 +24,22 @@ const BasicInfo = (props: IWagesProps) => {
         type="select"
         name="fixedWorkingDays"
         register={props.register('fixedWorkingDays')}
-        data={['일', '월', '화', '수', '목', '금', '토']}
-        defaultChecked={['월', '화', '수', '목', '금']}
-        fieldName={'fixedWorkingDays'}
+        data={[
+          { id: '0', name: '월' },
+          { id: '1', name: '화' },
+          { id: '2', name: '수' },
+          { id: '3', name: '목' },
+          { id: '4', name: '금' },
+          { id: '5', name: '토' },
+          { id: '6', name: '일' },
+        ]}
+        defaultChecked={[
+          { id: '0', name: '월' },
+          { id: '1', name: '화' },
+          { id: '2', name: '수' },
+          { id: '3', name: '목' },
+          { id: '4', name: '금' },
+        ]}
         textFillMode
       >
         소정근로요일
@@ -35,10 +48,20 @@ const BasicInfo = (props: IWagesProps) => {
         type="select"
         name="weekDays"
         register={props.register('weekDays')}
-        data={['일', '월', '화', '수', '목', '금', '토']}
-        defaultChecked={['토', '일']}
+        data={[
+          { id: '0', name: '월' },
+          { id: '1', name: '화' },
+          { id: '2', name: '수' },
+          { id: '3', name: '목' },
+          { id: '4', name: '금' },
+          { id: '5', name: '토' },
+          { id: '6', name: '일' },
+        ]}
+        defaultChecked={[
+          { id: '5', name: '토' },
+          { id: '6', name: '일' },
+        ]}
         setValue={props.setValue}
-        fieldName={'weekDays'}
         textFillMode
       >
         주휴요일

--- a/src/components/units/admin/manage/forms/wages/contractedLaborRules.tsx
+++ b/src/components/units/admin/manage/forms/wages/contractedLaborRules.tsx
@@ -95,18 +95,26 @@ const Select = styled.select`
   outline: none;
   border: 1px solid ${styleSet.colors.gray};
   padding: 0.5rem;
+  transition: all 0.3s ease-in-out;
+  :focus {
+    border: 1px solid ${styleSet.colors.primary};
+  }
 `;
 
 const HourBox = styled.div`
   display: flex;
-  border: 1px solid ${styleSet.colors.gray};
 `;
 
 const HourInput = styled.input`
   width: 5rem;
   padding: 0.5rem;
   outline: none;
-  border: none;
+  border: 1px solid ${styleSet.colors.gray};
+
+  transition: all 0.3s ease-in-out;
+  :focus {
+    border: 1px solid ${styleSet.colors.primary};
+  }
 `;
 
 const LabelPerHour = styled.label`
@@ -115,5 +123,6 @@ const LabelPerHour = styled.label`
   align-items: center;
   padding: 0.5rem;
   background-color: ${styleSet.colors.lightGray};
-  border-left: 1px solid ${styleSet.colors.gray};
+  border: 1px solid ${styleSet.colors.gray};
+  border-left: none;
 `;

--- a/src/components/units/admin/manage/forms/wages/maximumLaborRules.tsx
+++ b/src/components/units/admin/manage/forms/wages/maximumLaborRules.tsx
@@ -43,7 +43,7 @@ const MaximumLaborRules = (props: IWagesProps) => {
               </Select>
             </InputBox>
           </FormContent>
-          <Check01 text="휴일 포함" />
+          <Check01 text="휴일 포함" register={props.register('includeOff')} />
         </>
       )}
       <Footer onCancel={props.onCancel} />

--- a/src/components/units/admin/manage/manageSidebar/index.tsx
+++ b/src/components/units/admin/manage/manageSidebar/index.tsx
@@ -21,10 +21,6 @@ const ManageSidebarComponent = () => {
     { label: '근무일정 유형', path: 'shift-types' },
     { label: '근무일정 템플릿', path: 'shift-template' },
     { label: '휴가 유형', path: 'leave-types' },
-    { label: '휴가 발생 규칙', path: 'leave-accural-rule' },
-    { label: '스케쥴 패턴', path: 'schedule-patterns' },
-    { label: '커스텀 요청 유형', path: 'custom-request-types' },
-    { label: '승인 규칙', path: 'request-approval-rules' },
   ];
 
   const onClickChangeTab = (path: string) => async () => {
@@ -66,7 +62,7 @@ const TabContainer = styled.ul`
 
 const Tab = styled.li`
   display: block;
-  padding: 0.5rem 1.5rem;
+  padding: 0.75rem 1.5rem 0.5rem 1.5rem;
   cursor: pointer;
   transition: all 0.3s ease;
   :hover {


### PR DESCRIPTION
어드민 관리 리팩토링
  - input에 register 전부 연결.
  - 공통 컴포넌트가 아니었던 것 공통 컴포넌트로 전환.
  - select01의 데이터 타입 변경에 따른 기존 더미 데이터 타입 변경.

select01
  - inputData[] 타입 접근성을 위한 export 추가.
  - default value 가 있을 때, default value 가 체크되어 있지 않은 상태로 렌더링 되는 버그 수정.
    `checked={checkedList.includes(el)}` 를
    `checked={ checkedList.filter((listItem) => listItem.id === el.id).length > 0 } 로 변경.
    `
    **데이터 배열의 요소 타입을 객체로 바꾸면서 생긴 버그**.
    객체는 참조값이고 includes 메서드를 사용한 이전 방식으로는 참조값 대조가 되지 않아서 생긴 문제로 추정.
    객체의 id 값 대조로 변경하여 해결.

closed #127