### PR TITLE
:sparkles: (Scheduler): FEATURE: 근무일정 캘린더 데이터 표출 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.vscode

--- a/src/commons/utils/getDate.ts
+++ b/src/commons/utils/getDate.ts
@@ -5,3 +5,10 @@ export const getDate = (createdAt: string) => {
   const dd = String(date.getDate()).padStart(2, '0');
   return `${yyyy}.${mm}.${dd}`;
 };
+
+export const getStaticDateStr = (date: Date) => {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};

--- a/src/components/units/admin/scheduler/calendar/schedulerCalendar.presenter.tsx
+++ b/src/components/units/admin/scheduler/calendar/schedulerCalendar.presenter.tsx
@@ -1,4 +1,5 @@
 import { styleSet } from '../../../../../commons/styles/styleSet';
+import { getStaticDateStr } from '../../../../../commons/utils/getDate';
 import Btn01 from '../../../../commons/button/btn01';
 import Select01 from '../../../../commons/input/select01';
 import ArrowSvg from '../../../../commons/svg/arrows';
@@ -7,6 +8,7 @@ import CalendarElementContainer from '../elements/calendar/calendarElement.conta
 import { IDateData } from '../scheduler.types';
 import * as S from './schedulerCalendar.styles';
 import { ISchedulerCalendarProps } from './schedulerCalendar.types';
+import { v4 } from 'uuid';
 
 const getDateStr = (date: IDateData) => {
   let dayStr = date.day.split('-')[2] + '일';
@@ -18,8 +20,19 @@ const getDateStr = (date: IDateData) => {
   }
   return dayStr + ` (${date.dateStr})`;
 };
+const getTimeStr = (date: Date) => {
+  const hour = date.getHours().toString();
+  const minute = date.getMinutes().toString();
+  let timeStr = '';
+  if (hour.length !== 2) timeStr += '0';
+  timeStr += hour + ':';
+  if (minute.length !== 2) timeStr += '0';
+  timeStr += minute;
+  return timeStr;
+};
 
 const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
+  console.log(props.member);
   return (
     <S.Container>
       <S.TopWrapper>
@@ -61,6 +74,7 @@ const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
               defaultChecked={props.initOption?.organization}
               name={'organization'}
               role="organization"
+              left
             />
           </S.OptSectionWrapper>
         </S.OptBox>
@@ -82,12 +96,11 @@ const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
         <S.CalendarWrapper>
           <S.CalendarHeader>
             <S.CalendarHeaderItem> </S.CalendarHeaderItem>
-            {/* TODO: need type declaration */}
             {props.dateArray?.map((date: IDateData) => {
               const dayStr = getDateStr(date);
               return (
                 <S.CalendarHeaderItem
-                  key={date.index}
+                  key={v4()}
                   className={date.isToday ? 'today' : 'other'}
                 >
                   <S.Text>{dayStr}</S.Text>
@@ -103,14 +116,36 @@ const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
                     {props.dateArray?.map((date: any) => {
                       return (
                         <S.CalendarBodyItem
-                          key={date.index}
+                          key={v4()}
                           className={date.isToday ? 'today' : 'other'}
                         >
-                          <CalendarElementContainer
+                          {props.scheduleList?.map((schedule: any) => {
+                            if (
+                              schedule.member.id === member.id &&
+                              getStaticDateStr(new Date(schedule.date)) ===
+                                date.day
+                            ) {
+                              return (
+                                <CalendarElementContainer
+                                  key={String(schedule.id)}
+                                  startTime={getTimeStr(
+                                    new Date(schedule.startWorkTime),
+                                  )}
+                                  endTime={getTimeStr(
+                                    new Date(schedule.endWorkTime),
+                                  )}
+                                  member={member}
+                                  companyName={member.company.name}
+                                  color={styleSet.colors.primary}
+                                />
+                              );
+                            } else return <></>;
+                          })}
+                          {/* <CalendarElementContainer
                             member={member}
                             companyName={member.company.name}
-                            color={member.schedule.scheduleCategory.color}
-                          />
+                            color={styleSet.colors.primary}
+                          /> */}
                         </S.CalendarBodyItem>
                       );
                     })}
@@ -126,7 +161,7 @@ const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
             {props.dateArray?.map((date: any) => {
               return (
                 <S.CalendarFooterItem
-                  key={date.index}
+                  key={v4()}
                   className={date.isToday ? 'today' : 'other'}
                 ></S.CalendarFooterItem>
               );
@@ -139,7 +174,7 @@ const SchedulerCalendarPresenter = (props: ISchedulerCalendarProps) => {
             {props.dateArray?.map((date: any) => {
               return (
                 <S.CalendarFooterItem
-                  key={date.index}
+                  key={v4()}
                   className={date.isToday ? 'today' : 'other'}
                 ></S.CalendarFooterItem>
               );

--- a/src/components/units/admin/scheduler/calendar/schedulerCalendar.queries.ts
+++ b/src/components/units/admin/scheduler/calendar/schedulerCalendar.queries.ts
@@ -19,10 +19,10 @@ export const FETCH_SCHEDULE_LIST = gql`
       member {
         id
       }
-      company {
-        id
-        name
-      }
+      # company {
+      #   id
+      #   name
+      # }
       organization {
         id
         name
@@ -66,6 +66,29 @@ export const FETCH_ACCOUNT = gql`
   query fetchAccount {
     fetchAccount {
       id
+      company {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const FETCH_MEMBERS = gql`
+  query fetchMembers($companyId: String!) {
+    fetchMembers(companyId: $companyId) {
+      id
+      name
+      roleCategory {
+        id
+        duty
+        colorCode
+      }
+      organization {
+        id
+        name
+        color
+      }
       company {
         id
         name

--- a/src/components/units/admin/scheduler/elements/calendar/calendarElement.container.tsx
+++ b/src/components/units/admin/scheduler/elements/calendar/calendarElement.container.tsx
@@ -2,6 +2,6 @@ import CalendarElementPresenter from './calendarElement.presenter';
 import { ICalendarElementProps } from './calendarElement.types';
 
 const CalendarElementContainer = (props: ICalendarElementProps) => {
-  return <CalendarElementPresenter />;
+  return <CalendarElementPresenter {...props} />;
 };
 export default CalendarElementContainer;


### PR DESCRIPTION
근무일정 캘린더 뷰 fetched 데이터 유저별로 뿌려주는 기능 구현 완료
(보완요망) 조직별로 필터는 가능하나, 직무별로 필터가 불가능한 점 백엔드에 요청해야함
(보완요망) 표출되는 맴버를 직무 및 조직 별로 필터 가능하도록 수정해야함

closed #149