### PR TITLE
🚑  (Select01): HOTFIX: 공통 컴포넌트 Select01 버그 수정

### DIFF
--- a/src/components/commons/input/select01.tsx
+++ b/src/components/commons/input/select01.tsx
@@ -6,6 +6,7 @@ import {
   MouseEvent,
   SetStateAction,
   useCallback,
+  useEffect,
   useState,
 } from 'react';
 import {
@@ -43,18 +44,18 @@ interface IStyle {
 }
 
 const Select01 = (props: ISelectProps) => {
-  if (props.setState) props.register = undefined;
+  if (props.setState && props.register) props.register = undefined;
   const [isOpen, setIsOpen] = useState(false);
-  const [saveChecked, setSaveChecked] = useState<InputData[]>(
-    props.defaultChecked && props.defaultChecked.length > 0
-      ? props.defaultChecked
-      : [],
-  );
-  const [checkedList, setCheckedList] = useState<InputData[]>(
-    props.defaultChecked && props.defaultChecked.length > 0
-      ? props.defaultChecked
-      : [],
-  );
+  const [saveChecked, setSaveChecked] = useState<InputData[]>([]);
+  const [checkedList, setCheckedList] = useState<InputData[]>([]);
+  const [data] = useState<InputData[]>(props.data ?? []);
+
+  useEffect(() => {
+    if (props.defaultChecked && props.defaultChecked.length > 0) {
+      setSaveChecked(props.defaultChecked);
+      setCheckedList(props.defaultChecked);
+    }
+  }, [props.defaultChecked]);
 
   const [keyword, setKeyword] = useState('');
 
@@ -62,17 +63,18 @@ const Select01 = (props: ISelectProps) => {
     (checked) => {
       if (checked) {
         const checkedListArray: InputData[] = [];
-        props.data?.forEach((list) => checkedListArray.push(list));
+        data.forEach((list) => checkedListArray.push(list));
         setCheckedList(checkedListArray);
       } else setCheckedList([]);
     },
-    [props.data],
+    [data],
   );
 
   const onCheckedElement = useCallback(
     (checked, selectedTarget) => {
       if (checked) setCheckedList([...checkedList, selectedTarget]);
-      else setCheckedList(checkedList.filter((el) => el !== selectedTarget));
+      else
+        setCheckedList(checkedList.filter((el) => el.id !== selectedTarget.id));
     },
     [checkedList],
   );
@@ -132,7 +134,7 @@ const Select01 = (props: ISelectProps) => {
                 ? checkedList.map((data) => data.name).join(',')
                 : `${checkedList.length} 선택됨`}
             </span>
-          ) : props.data?.length ? (
+          ) : data.length ? (
             '선택 안됨'
           ) : (
             '선택 가능한 옵션 없음'
@@ -163,14 +165,14 @@ const Select01 = (props: ISelectProps) => {
                 checked={
                   checkedList.length === 0
                     ? false
-                    : checkedList.length === props.data?.length
+                    : checkedList.length === data?.length
                 }
                 onChange={(event) => onCheckedAll(event.target.checked)}
               />
               <Options className="options">
                 <Divider style={{ margin: '0.5rem 0' }} />
-                {props.data && props.data.length > 0
-                  ? props.data
+                {data && data.length > 0
+                  ? data
                       .filter((el) => el.name.includes(keyword))
                       .map((el) => (
                         <Check01

--- a/src/components/units/admin/manage/forms/oranization.tsx
+++ b/src/components/units/admin/manage/forms/oranization.tsx
@@ -21,8 +21,8 @@ const OrganizationForm = (props: IFormProps) => {
           setValue={props.setValue}
           register={props.register('location')}
           data={[
-            { id: '123', name: '패파' },
-            { id: '1234', name: '패파' },
+            { id: '123', name: '패파1' },
+            { id: '1234', name: '패파2' },
           ]}
         >
           출퇴근 장소들

--- a/src/components/units/admin/profile/adminProfile.presenter.tsx
+++ b/src/components/units/admin/profile/adminProfile.presenter.tsx
@@ -52,7 +52,11 @@ const AdminProfileUI = (props: IAdminProfileProps) => {
               register={props.register('organization')}
               setValue={props.setValue}
               name={'oranization'}
-              data={['BUSKER', 'ZERO9', 'WETREKKING'] || undefined}
+              data={[
+                { id: 'busker', name: 'BUSKER' },
+                { id: 'zero9', name: 'ZERO9' },
+                { id: 'wetrekking', name: 'WETREKKING' },
+              ]}
             />
           </S.FormContents>
           <S.FormContents>


### PR DESCRIPTION
공통 컴포넌트 Select01

항목을 클릭하여 check 후 적용 버튼을 클릭해 값을 저장하고 나면 동일한 항목에 **클릭 이벤트가 먹통**이 되고, 
data를 useState 훅의 **state값으로 담아서 넣어주면 정상적으로 작동**하는 현상 발생.

data의 요소 타입이 문자열에서 객체로 바뀌면서 개별 클릭 시 값 대조가 제대로 되지 않아서 생긴 문제로 추정

state와 non-state 두 종류의 값 모두 정상 작동하도록

`const [data] = useState<InputData[]>(props.data ?? []);` 추가 및

`else setCheckedList(checkedList.filter((el) => el !== selectedTarget));` 를 
`else setCheckedList(checkedList.filter((el) -> el.id !== selectedTarget.id));` 로 수정

closed #151