### PR TITLE
:sparkles: (updateMemberForm): FEATURE: 직원 정보 수정 시, 기본값 로딩

### DIFF
--- a/pages/admin/manage/members/index.tsx
+++ b/pages/admin/manage/members/index.tsx
@@ -1,7 +1,27 @@
+import { useQuery } from '@apollo/client';
+import { IQuery } from '../../../../src/commons/types/generated/types';
 import Manage from '../../../../src/components/units/admin/manage/manage.container';
+import {
+  FETCH_MEMBERS,
+  FETCH_ORGANIZATIONS,
+  FETCH_ROLE_CATEGORIES,
+} from '../../../../src/components/units/admin/manage/manage.queries';
 
 const ManageMember = () => {
-  return <Manage tab="직원" />;
+  const { data: members } =
+    useQuery<Pick<IQuery, 'fetchMembers'>>(FETCH_MEMBERS);
+  const { data: organizations } =
+    useQuery<Pick<IQuery, 'fetchOrganizations'>>(FETCH_ORGANIZATIONS);
+  const { data: roleCategories } = useQuery<
+    Pick<IQuery, 'fetchRoleCategories'>
+  >(FETCH_ROLE_CATEGORIES);
+
+  const data = {
+    members,
+    organizations,
+    roleCategories,
+  };
+  return <Manage tab="직원" data={data} />;
 };
 
 export default ManageMember;

--- a/src/components/units/admin/manage/formsInModal/common/footer.tsx
+++ b/src/components/units/admin/manage/formsInModal/common/footer.tsx
@@ -5,14 +5,26 @@ import Btn01 from '../../../../../commons/button/btn01';
 
 interface IFooterProps {
   onCancel: () => void;
+  isEdit?: boolean;
+  onDelete?: () => void;
 }
 
 const Footer = (props: IFooterProps) => {
   return (
     <>
-      <Divider style={{ marginBottom: '0.5rem' }} />
+      <Divider style={{ marginBottom: '0.5rem', transform: 'scaleX(1.05)' }} />
       <Wrapper>
-        <div></div>
+        <DeleteButtonBox>
+          {props.isEdit && (
+            <Btn01
+              onClick={props.onDelete}
+              text="비활성화하기"
+              type="button"
+              bdC="#ddd"
+              color="red"
+            />
+          )}
+        </DeleteButtonBox>
         <ButtonBox>
           <Btn01
             onClick={props.onCancel}
@@ -21,7 +33,7 @@ const Footer = (props: IFooterProps) => {
             bdC="#ddd"
           />
           <Btn01
-            text="추가하기"
+            text={props.isEdit ? '수정하기' : '추가하기'}
             color="#fff"
             bgC={styleSet.colors.primary}
             bdC={styleSet.colors.primary}
@@ -38,7 +50,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0rem;
 `;
 
 const ButtonBox = styled.div`
@@ -47,3 +59,5 @@ const ButtonBox = styled.div`
   align-items: center;
   gap: 1rem;
 `;
+
+const DeleteButtonBox = styled.div``;

--- a/src/components/units/admin/manage/formsInModal/common/form.types.ts
+++ b/src/components/units/admin/manage/formsInModal/common/form.types.ts
@@ -7,6 +7,7 @@ import {
   UseFormReset,
   UseFormSetValue,
 } from 'react-hook-form';
+import { IQuery } from '../../../../../../commons/types/generated/types';
 
 export interface IFormProps {
   register: UseFormRegister<FieldValues>;
@@ -18,4 +19,9 @@ export interface IFormProps {
   control: Control;
   editTarget: any;
   tab: string;
+  data?: {
+    members?: Pick<IQuery, 'fetchMembers'>;
+    organizations?: Pick<IQuery, 'fetchOrganizations'>;
+    roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+  };
 }

--- a/src/components/units/admin/manage/manage.container.tsx
+++ b/src/components/units/admin/manage/manage.container.tsx
@@ -4,6 +4,8 @@ import ManagePresenter from './manage.presenter';
 import { IManageProps } from './manage.types';
 
 const Manage = (props: IManageProps) => {
+  console.log('container start');
+  console.log(props.data);
   const { register, handleSubmit, setValue, reset, control } = useForm();
   const [isOpen, setIsOpen] = useState(false);
   const [aniMode, setAniMode] = useState(false);
@@ -51,6 +53,7 @@ const Manage = (props: IManageProps) => {
   const tab = props.tab === '지점' && isLocation ? '출퇴근 장소' : props.tab;
   return (
     <ManagePresenter
+      data={props.data}
       editTarget={editTarget}
       onOpenEdit={onOpenEdit}
       isOpen={isOpen}

--- a/src/components/units/admin/manage/manage.presenter.tsx
+++ b/src/components/units/admin/manage/manage.presenter.tsx
@@ -16,12 +16,19 @@ const ManagePresenter = (props: IManagePresenterProps) => {
           isOpen={props.isOpen}
           aniMode={props.aniMode}
           onCancel={props.onClickCloseModal}
-          title={`${props.tab} ${props.editTarget ? `수정하기` : `추가하기`} `}
+          title={` ${
+            props.editTarget
+              ? props.tab === '직원'
+                ? `${String(props.editTarget?.name)}의 정보 수정하기`
+                : `${props.tab} 수정하기`
+              : `${props.tab} 추가하기`
+          } `}
         >
           <Form
             {...props.formProps}
             tab={props.tab}
             editTarget={props.editTarget}
+            data={props.data}
           />
         </FallingModal>
       )}
@@ -68,6 +75,7 @@ const ManagePresenter = (props: IManagePresenterProps) => {
             </S.OrganizationTabBox>
           )}
           <ScrollableTable
+            data={props.data}
             onOpenEdit={props.onOpenEdit}
             tab={props.tab}
             isLocation={props.isLocation}

--- a/src/components/units/admin/manage/manage.queries.ts
+++ b/src/components/units/admin/manage/manage.queries.ts
@@ -17,3 +17,22 @@ export const FETCH_MEMBERS = gql`
     }
   }
 `;
+
+export const FETCH_ORGANIZATIONS = gql`
+  query {
+    fetchOrganizations {
+      id
+      name
+    }
+  }
+`;
+
+export const FETCH_ROLE_CATEGORIES = gql`
+  query {
+    fetchRoleCategories {
+      id
+      duty
+      colorCode
+    }
+  }
+`;

--- a/src/components/units/admin/manage/manage.types.ts
+++ b/src/components/units/admin/manage/manage.types.ts
@@ -8,6 +8,7 @@ import {
   UseFormReset,
   UseFormSetValue,
 } from 'react-hook-form';
+import { IQuery } from '../../../../commons/types/generated/types';
 
 export interface IManagePresenterProps {
   isOpen: boolean;
@@ -29,10 +30,20 @@ export interface IManagePresenterProps {
   isLocation: boolean;
   onOpenEdit: (el: any) => void;
   editTarget: any;
+  data?: {
+    members?: Pick<IQuery, 'fetchMembers'>;
+    organizations?: Pick<IQuery, 'fetchOrganizations'>;
+    roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+  };
 }
 
 export interface IManageProps {
   tab: string;
+  data?: {
+    members?: Pick<IQuery, 'fetchMembers'>;
+    organizations?: Pick<IQuery, 'fetchOrganizations'>;
+    roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+  };
 }
 
 export interface IStyle {

--- a/src/components/units/admin/manage/scrollableTable/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/index.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@apollo/client';
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
@@ -6,15 +5,19 @@ import { useRecoilState } from 'recoil';
 import { isAdminSidebarState } from '../../../../../commons/store';
 import { styleSet } from '../../../../../commons/styles/styleSet';
 import { IMember, IQuery } from '../../../../../commons/types/generated/types';
-import { FETCH_MEMBERS } from '../manage.queries';
+
 import Check01 from '../../../../commons/input/check01';
 import RowDataCells from './rowDataCells';
 
 interface IScrollableTableProps {
   tab: string;
   isLocation?: boolean;
-  data?: any;
   onOpenEdit: (el: any) => void;
+  data?: {
+    members?: Pick<IQuery, 'fetchMembers'>;
+    organizations?: Pick<IQuery, 'fetchOrganizations'>;
+    roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+  };
 }
 
 interface IStyle {
@@ -28,14 +31,14 @@ let bodyData: IMember[] | string[] = [];
 const HTML_TD_TAG = 'TD';
 
 const ScrollableTable = (props: IScrollableTableProps) => {
-  const { data } = useQuery<Pick<IQuery, 'fetchMembers'>>(FETCH_MEMBERS);
+  console.log('table is re-redering!');
 
   const [checkedList, setCheckedList] = useState<
     Array<string | {} | JSX.Element>
   >([]);
   const router = useRouter();
   const [isAdminSidebar] = useRecoilState(isAdminSidebarState);
-  console.log('checkedList:', checkedList);
+
   if (props.tab === '직원') {
     // fetchMember
     // 얻어와야하는 것
@@ -54,7 +57,7 @@ const ScrollableTable = (props: IScrollableTableProps) => {
       '합류 여부',
       '메모',
     ];
-    bodyData = data?.fetchMembers ?? [];
+    bodyData = props.data?.members?.fetchMembers ?? [];
   } else if (props.tab === '지점' || props.tab === '출퇴근 장소') {
     if (props.isLocation) {
       headerData = ['출퇴근 장소', '근무지 주소', '좌표', 'WiFi', '메모'];

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/index.tsx
@@ -23,7 +23,7 @@ const RowDataCells = (props: IRowDataCellsProps) => {
     case '휴가 유형':
       return <>휴가 유형탭</>;
     default:
-      return <>직웝탭</>;
+      return <MemberData data={props.data} />;
   }
 };
 

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/members/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/members/index.tsx
@@ -7,7 +7,7 @@ const MemberData = (props: { data?: IMember }) => {
     <>
       <Td>{props.data?.name}</Td>
       {/* <Td>{props.data?.accessAuth ?? ''}</Td> */}
-      <Td>{''}</Td>
+      <Td>{'개발 예정'}</Td>
       <Td>{props.data?.joinDate ? getDate(props.data?.joinDate) : ''}</Td>
       <Td>{props.data?.organization?.name}</Td>
       <Td>{props.data?.roleCategory?.duty}</Td>


### PR DESCRIPTION
# 주요 변경 사항
- 직원 수정 Modal 열면 defaultValue 삽입 ( 현재 개발 중 또는 예정인 것들 제외 )
  수정을 위해 클릭한 요소에 담겨있는 정보를 그대로 가져와서 기본값으로 삽입.
## 번외 변경 사항
- 불필요한 API 호출을 막기 위해 fetchMembers API 선언부 위치 최상단(pages/admin/members)으로 변경
- 수정 Modal의 footer에 비활성화 버튼 추가
- 직원 추가 Modal의 예약 전송 탭 퍼블리싱

closed #190