### PR TITLE
:sparkles: (fetchSchedules): FEATURE: 근무일정 유형/템플릿, 휴가 유형  fetch API 연결

### DIFF
--- a/pages/admin/manage/leave-types/index.tsx
+++ b/pages/admin/manage/leave-types/index.tsx
@@ -1,7 +1,0 @@
-import Manage from '../../../../src/components/units/admin/manage/manage.container';
-
-const LeaveTypes = () => {
-  return <Manage tab="휴가 유형" />;
-};
-
-export default LeaveTypes;

--- a/pages/admin/manage/schedule-category/index.tsx
+++ b/pages/admin/manage/schedule-category/index.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@apollo/client';
+import { IQuery } from '../../../../src/commons/types/generated/types';
+import Manage from '../../../../src/components/units/admin/manage/manage.container';
+import { FETCH_ALL_SCHEDULE_CATEGORY } from '../../../../src/components/units/admin/manage/manage.queries';
+
+const ScheduleCategory = () => {
+  const { data: scheduleCategories } = useQuery<
+    Pick<IQuery, 'fetchAllScheduleCategories'>
+  >(FETCH_ALL_SCHEDULE_CATEGORY);
+  const data = {
+    scheduleCategories,
+  };
+  return <Manage tab="근무일정 유형" data={data} />;
+};
+
+export default ScheduleCategory;

--- a/pages/admin/manage/schedule-template/index.tsx
+++ b/pages/admin/manage/schedule-template/index.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@apollo/client';
+import { IQuery } from '../../../../src/commons/types/generated/types';
+import Manage from '../../../../src/components/units/admin/manage/manage.container';
+import { FETCH_ALL_SCHEDULE_TEMPLATE } from '../../../../src/components/units/admin/manage/manage.queries';
+
+const ScheduleTemplate = () => {
+  const { data: scheduleTemplates } = useQuery<
+    Pick<IQuery, 'fetchAllScheduleTemplates'>
+  >(FETCH_ALL_SCHEDULE_TEMPLATE);
+  const data = {
+    scheduleTemplates,
+  };
+  return <Manage tab="근무일정 템플릿" data={data} />;
+};
+
+export default ScheduleTemplate;

--- a/pages/admin/manage/shift-template/index.tsx
+++ b/pages/admin/manage/shift-template/index.tsx
@@ -1,7 +1,0 @@
-import Manage from '../../../../src/components/units/admin/manage/manage.container';
-
-const ShiftTemplate = () => {
-  return <Manage tab="근무일정 템플릿" />;
-};
-
-export default ShiftTemplate;

--- a/pages/admin/manage/shift-types/index.tsx
+++ b/pages/admin/manage/shift-types/index.tsx
@@ -1,7 +1,0 @@
-import Manage from '../../../../src/components/units/admin/manage/manage.container';
-
-const ShiftTypes = () => {
-  return <Manage tab="근무일정 유형" />;
-};
-
-export default ShiftTypes;

--- a/pages/admin/manage/vacation-category/index.tsx
+++ b/pages/admin/manage/vacation-category/index.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@apollo/client';
+import { IQuery } from '../../../../src/commons/types/generated/types';
+import Manage from '../../../../src/components/units/admin/manage/manage.container';
+import { FETCH_VACATION_CATEGORYS } from '../../../../src/components/units/admin/manage/manage.queries';
+
+const VacationCategory = () => {
+  const { data: vacationCategories } = useQuery<
+    Pick<IQuery, 'fetchVacationCategorys'>
+  >(FETCH_VACATION_CATEGORYS);
+  const data = {
+    vacationCategories,
+  };
+  return <Manage tab="휴가 유형" data={data} />;
+};
+
+export default VacationCategory;

--- a/pages/admin/manage/wages/index.tsx
+++ b/pages/admin/manage/wages/index.tsx
@@ -1,6 +1,8 @@
+// import { useQuery } from '@apollo/client';
 import Manage from '../../../../src/components/units/admin/manage/manage.container';
 
 const Wages = () => {
+  // const {data: wages} = useQuery<>();
   return <Manage tab="근로 정보" />;
 };
 

--- a/src/components/commons/layoutuser/layout.styles.ts
+++ b/src/components/commons/layoutuser/layout.styles.ts
@@ -138,13 +138,14 @@ export const Mypage = styled.article`
 // Sidebar
 export const Sidebar = styled.section`
   height: 100vh;
-  width: 400px;
+  min-width: 250px;
   padding: 1rem;
-  box-sizing: content-box;
+  box-sizing: border-box;
   box-shadow: 1px 0px 5px #eee;
   &.min {
     width: 300px;
   }
+  flex: 1 1 300px;
 `;
 
 export const H1 = styled.h1`

--- a/src/components/units/admin/manage/formsInModal/index.tsx
+++ b/src/components/units/admin/manage/formsInModal/index.tsx
@@ -2,11 +2,11 @@ import { IFormProps } from './common/form.types';
 import AttendanceLocation from './attendanceLocation';
 import LeaveTypes from './leaveTypes';
 import MemberForm from './member/member';
-import ShiftTemplate from './shiftTemplate';
-import ShiftTypes from './shiftTypes';
 import Wages from './wages';
 import RoleCategoryForm from './roleCategory';
 import OrganizationFormContainer from './oraganization/organization.container';
+import ScheduleTemplate from './scheduleTemplate';
+import ScheduleCategory from './scheduleCategory';
 
 const Form = (props: IFormProps) => {
   if (props.tab === '직원') return <MemberForm {...props} />;
@@ -14,8 +14,8 @@ const Form = (props: IFormProps) => {
   if (props.tab === '출퇴근 장소') return <AttendanceLocation {...props} />;
   if (props.tab === '직무') return <RoleCategoryForm {...props} />;
   if (props.tab === '근로 정보') return <Wages {...props} />;
-  if (props.tab === '근무일정 유형') return <ShiftTypes {...props} />;
-  if (props.tab === '근무일정 템플릿') return <ShiftTemplate {...props} />;
+  if (props.tab === '근무일정 유형') return <ScheduleCategory {...props} />;
+  if (props.tab === '근무일정 템플릿') return <ScheduleTemplate {...props} />;
   if (props.tab === '휴가 유형') return <LeaveTypes {...props} />;
   return <MemberForm {...props} />;
 };

--- a/src/components/units/admin/manage/formsInModal/member/member.tsx
+++ b/src/components/units/admin/manage/formsInModal/member/member.tsx
@@ -108,7 +108,7 @@ const MemberForm = (props: IFormProps) => {
   const roleCategoryDefaultValue = props.editTarget?.roleCategory && [
     {
       id: String(props.editTarget?.roleCategory?.id),
-      name: String(props.editTarget?.roleCategory?.duty),
+      name: String(props.editTarget?.roleCategory?.name),
     },
   ];
 

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory.tsx
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory.tsx
@@ -6,7 +6,7 @@ import { IFormProps } from './common/form.types';
 import InputLabel from '../../../../commons/inputLabel';
 import Memo from './common/memo';
 
-const ShiftTypes = (props: IFormProps) => {
+const ScheduleCategory = (props: IFormProps) => {
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
@@ -43,7 +43,7 @@ const ShiftTypes = (props: IFormProps) => {
   );
 };
 
-export default ShiftTypes;
+export default ScheduleCategory;
 
 const Wrapper = styled.div`
   width: 30rem;

--- a/src/components/units/admin/manage/formsInModal/scheduleTemplate.tsx
+++ b/src/components/units/admin/manage/formsInModal/scheduleTemplate.tsx
@@ -7,7 +7,7 @@ import Memo from './common/memo';
 
 const { RangePicker } = TimePicker;
 
-const ShiftTemplate = (props: IFormProps) => {
+const ScheduleTemplate = (props: IFormProps) => {
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
@@ -84,7 +84,7 @@ const ShiftTemplate = (props: IFormProps) => {
   );
 };
 
-export default ShiftTemplate;
+export default ScheduleTemplate;
 
 const Wrapper = styled.div`
   width: 30rem;

--- a/src/components/units/admin/manage/manage.container.tsx
+++ b/src/components/units/admin/manage/manage.container.tsx
@@ -5,9 +5,7 @@ import { IManageProps } from './manage.types';
 const Manage = (props: IManageProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [aniMode, setAniMode] = useState(false);
-
   const [isLocation, setIsLocation] = useState(false);
-
   const [editTarget, setEditTarget] = useState();
 
   const onClickOpenModal = () => {

--- a/src/components/units/admin/manage/manage.queries.ts
+++ b/src/components/units/admin/manage/manage.queries.ts
@@ -29,7 +29,7 @@ export const FETCH_ORGANIZATIONS = gql`
       lat
       lng
       description
-      color
+      # color
       # scheduleTemplate {
       #   id
       #   name
@@ -55,6 +55,72 @@ export const FETCH_ROLE_CATEGORIES = gql`
       #   endTime
       #   colorCode
       # }
+    }
+  }
+`;
+
+export const FETCH_ALL_SCHEDULE_CATEGORY = gql`
+  query {
+    fetchAllScheduleCategories {
+      id
+      name
+      color
+      memo
+      isOvertime
+      isNotHolidayWork
+    }
+  }
+`;
+
+export const FETCH_ALL_SCHEDULE_TEMPLATE = gql`
+  query {
+    fetchAllScheduleTemplates {
+      id
+      name
+      breakTime
+      startTime
+      endTime
+      colorCode
+      memo
+      scheduleCategory {
+        id
+        name
+      }
+      organization {
+        id
+        name
+      }
+      roleCategory {
+        id
+        name
+      }
+    }
+  }
+`;
+
+// export const FETCH_WAGES = gql`
+//   query {
+
+//   }
+// `
+
+export const FETCH_VACATION_CATEGORYS = gql`
+  query {
+    fetchVacationCategorys {
+      id
+      name
+      timeOption
+      memo
+      paidTime
+      deductionDays
+      organization {
+        id
+        name
+      }
+      roleCategory {
+        id
+        name
+      }
     }
   }
 `;

--- a/src/components/units/admin/manage/manage.types.ts
+++ b/src/components/units/admin/manage/manage.types.ts
@@ -25,6 +25,9 @@ export interface IManageProps {
     members?: Pick<IQuery, 'fetchMembers'>;
     organizations?: Pick<IQuery, 'fetchOrganizations'>;
     roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+    scheduleCategories?: Pick<IQuery, 'fetchAllScheduleCategories'>;
+    scheduleTemplates?: Pick<IQuery, 'fetchAllScheduleTemplates'>;
+    vacationCategories?: Pick<IQuery, 'fetchVacationCategorys'>;
   };
 }
 

--- a/src/components/units/admin/manage/manageSidebar/index.tsx
+++ b/src/components/units/admin/manage/manageSidebar/index.tsx
@@ -18,9 +18,9 @@ const ManageSidebarComponent = () => {
     { label: '지점', path: 'organization' },
     { label: '직무', path: 'role-category' },
     { label: '근로정보', path: 'wages' },
-    { label: '근무일정 유형', path: 'shift-types' },
-    { label: '근무일정 템플릿', path: 'shift-template' },
-    { label: '휴가 유형', path: 'leave-types' },
+    { label: '근무일정 유형', path: 'schedule-category' },
+    { label: '근무일정 템플릿', path: 'schedule-template' },
+    { label: '휴가 유형', path: 'vacation-category' },
   ];
 
   const onClickChangeTab = (path: string) => async () => {

--- a/src/components/units/admin/manage/scrollableTable/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/index.tsx
@@ -9,6 +9,9 @@ import {
   IOrganization,
   IQuery,
   IRoleCategory,
+  IScheduleCategory,
+  IScheduleTemplate,
+  IVacationCategory,
 } from '../../../../../commons/types/generated/types';
 
 import Check01 from '../../../../commons/input/check01';
@@ -16,12 +19,16 @@ import RowDataCells from './rowDataCells';
 
 interface IScrollableTableProps {
   tab: string;
-  isLocation?: boolean;
   onOpenEdit: (el: any) => void;
+
+  isLocation?: boolean;
   data?: {
     members?: Pick<IQuery, 'fetchMembers'>;
     organizations?: Pick<IQuery, 'fetchOrganizations'>;
     roleCategories?: Pick<IQuery, 'fetchRoleCategories'>;
+    scheduleCategories?: Pick<IQuery, 'fetchAllScheduleCategories'>;
+    scheduleTemplates?: Pick<IQuery, 'fetchAllScheduleTemplates'>;
+    vacationCategories?: Pick<IQuery, 'fetchVacationCategorys'>;
   };
 }
 
@@ -30,8 +37,18 @@ interface IStyle {
   isAdminSidebar?: boolean;
 }
 
+type IBodyData = Array<
+  | IMember
+  | IOrganization
+  | IRoleCategory
+  | IScheduleCategory
+  | IScheduleTemplate
+  | IVacationCategory
+  | String
+>;
+
 let headerData: string[] = [];
-let bodyData: IMember[] | IOrganization[] | string[] | IRoleCategory[] = [];
+let bodyData: IBodyData = [];
 
 const HTML_TD_TAG = 'TD';
 
@@ -43,9 +60,6 @@ const ScrollableTable = (props: IScrollableTableProps) => {
   const [isAdminSidebar] = useRecoilState(isAdminSidebarState);
 
   if (props.tab === '직원') {
-    // fetchMember
-    // 얻어와야하는 것
-    // - roles
     headerData = [
       '이름',
       '액세스 권한',
@@ -101,22 +115,7 @@ const ScrollableTable = (props: IScrollableTableProps) => {
       '휴일근무 미적용 여부',
       '메모',
     ];
-    bodyData = [
-      '외근',
-      // <div
-      //   key="key"
-      //   style={{
-      //     width: '25px',
-      //     height: '25px',
-      //     borderRadius: '5px',
-      //     backgroundColor: 'tomato',
-      //     marginLeft: '2px',
-      //   }}
-      // ></div>,
-      'X',
-      'O',
-      '하위하위',
-    ];
+    bodyData = props.data?.scheduleCategories?.fetchAllScheduleCategories ?? [];
   } else if (props.tab === '근무일정 템플릿') {
     headerData = [
       '템플릿명',
@@ -128,25 +127,7 @@ const ScrollableTable = (props: IScrollableTableProps) => {
       '색깔',
       '메모',
     ];
-    bodyData = [
-      '오전근무',
-      '09:00 - 13:00',
-      '재택근무',
-      '패파',
-      '프론트엔드',
-      '자동 휴게시간',
-      // <div
-      //   key="key"
-      //   style={{
-      //     width: '25px',
-      //     height: '25px',
-      //     borderRadius: '5px',
-      //     backgroundColor: 'gray',
-      //     marginLeft: '2px',
-      //   }}
-      // ></div>,
-      '히히',
-    ];
+    bodyData = props.data?.scheduleTemplates?.fetchAllScheduleTemplates ?? [];
   } else if (props.tab === '휴가 유형') {
     headerData = [
       '휴가 유형',
@@ -157,7 +138,7 @@ const ScrollableTable = (props: IScrollableTableProps) => {
       '차감 일수',
       '메모',
     ];
-    bodyData = ['반차', '패파', '프론트엔드', '하루 종일', '8h', '1', '메모'];
+    bodyData = props.data?.vacationCategories?.fetchVacationCategorys ?? [];
   }
 
   const onCheckedAll = useCallback((checked) => {

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/index.tsx
@@ -2,14 +2,26 @@ import {
   IMember,
   IOrganization,
   IRoleCategory,
+  IScheduleCategory,
+  IScheduleTemplate,
+  IVacationCategory,
 } from '../../../../../../commons/types/generated/types';
 import MemberData from './members';
 import OrganizationData from './organization';
 import RoleCategoryData from './roleCategory';
+import ScheduleCategoryData from './scheduleCategory';
+import ScheduleTemplateData from './scheduleTemplate';
+import VacationCategoryData from './vacationCategory';
+import WageData from './wages';
 
 export interface IRowDataCellsProps {
   tab: string;
-  data?: IMember & IOrganization & IRoleCategory;
+  data?: IMember &
+    IOrganization &
+    IRoleCategory &
+    IScheduleCategory &
+    IScheduleTemplate &
+    IVacationCategory;
 }
 
 const RowDataCells = (props: IRowDataCellsProps) => {
@@ -21,13 +33,13 @@ const RowDataCells = (props: IRowDataCellsProps) => {
     case '직무':
       return <RoleCategoryData data={props.data} />;
     case '근로 정보':
-      return <>근로 정보탭</>;
+      return <WageData data={props.data} />;
     case '근무일정 유형':
-      return <>근무일정 유형탭</>;
+      return <ScheduleCategoryData data={props.data} />;
     case '근무일정 템플릿':
-      return <>근무일정 템플릿탭</>;
+      return <ScheduleTemplateData data={props.data} />;
     case '휴가 유형':
-      return <>휴가 유형탭</>;
+      return <VacationCategoryData data={props.data} />;
     default:
       return <MemberData data={props.data} />;
   }

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/organization/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/organization/index.tsx
@@ -8,7 +8,8 @@ const OrganizationData = (props: { data?: IOrganization }) => {
       <Td></Td>
       <Td>{props.data?.address}</Td>
       <Td>
-        ({props.data?.lat}, {props.data?.lng}) [반경m]
+        ({Number(props.data?.lat).toFixed(5)},{' '}
+        {Number(props.data?.lng).toFixed(5)}) [반경m]
       </Td>
       <Td>{'와이파이 주소'}</Td>
       <Td>{props.data?.description}</Td>

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/scheduleCategory/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/scheduleCategory/index.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { IScheduleCategory } from '../../../../../../../commons/types/generated/types';
+
+interface IStyle {
+  color?: string;
+}
+
+const ScheduleCategoryData = (props: { data?: IScheduleCategory }) => {
+  return (
+    <>
+      <Td>{props.data?.name}</Td>
+      <Td>
+        <ColorBox color={props.data?.color}></ColorBox>
+      </Td>
+      <Td>{props.data?.isOvertime ? 'O' : 'X'}</Td>
+      <Td>{props.data?.isNotHolidayWork ? 'O' : 'X'}</Td>
+      <Td>{props.data?.memo}</Td>
+    </>
+  );
+};
+
+export default ScheduleCategoryData;
+
+const Td = styled.td`
+  text-align: left;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
+  min-width: 100px;
+`;
+
+const ColorBox = styled.div`
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: ${({ color }: IStyle) => color};
+  border-radius: 0.2rem;
+`;

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/scheduleTemplate/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/scheduleTemplate/index.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import { IScheduleTemplate } from '../../../../../../../commons/types/generated/types';
+
+interface IStyle {
+  color?: string;
+}
+
+const ScheduleTemplateData = (props: { data?: IScheduleTemplate }) => {
+  return (
+    <>
+      <Td>{props.data?.name}</Td>
+      <Td>
+        {props.data?.startTime} - {props.data?.endTime}
+      </Td>
+      <Td>{props.data?.scheduleCategory?.name}</Td>
+      <Td>{props.data?.organization.map((el) => el.name).join(',')}</Td>
+      <Td>{props.data?.roleCategory.map((el) => el.name).join(',')}</Td>
+      <Td>{props.data?.breakTime}</Td>
+      <Td>
+        <ColorBox color={props.data?.colorCode}></ColorBox>
+      </Td>
+      <Td>{props.data?.memo}</Td>
+    </>
+  );
+};
+
+export default ScheduleTemplateData;
+
+const Td = styled.td`
+  text-align: left;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
+  min-width: 100px;
+`;
+
+const ColorBox = styled.div`
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: ${({ color }: IStyle) => color};
+  border-radius: 0.2rem;
+`;

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/vacationCategory/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/vacationCategory/index.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+import { IVacationCategory } from '../../../../../../../commons/types/generated/types';
+const VacationCategoryData = (props: { data?: IVacationCategory }) => {
+  return (
+    <>
+      <Td>{props.data?.name}</Td>
+      <Td>{props.data?.organization.name}</Td>
+      <Td>{props.data?.roleCategory.name}</Td>
+      <Td>{props.data?.timeOption}</Td>
+      <Td>{props.data?.paidTime}h</Td>
+      <Td>{props.data?.deductionDays}</Td>
+      <Td>{props.data?.memo}</Td>
+    </>
+  );
+};
+
+export default VacationCategoryData;
+
+const Td = styled.td`
+  text-align: left;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
+  min-width: 100px;
+`;

--- a/src/components/units/admin/manage/scrollableTable/rowDataCells/wages/index.tsx
+++ b/src/components/units/admin/manage/scrollableTable/rowDataCells/wages/index.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+const WageData = (props: { data?: any }) => {
+  return (
+    <>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+      <Td>{'개발중'}</Td>
+    </>
+  );
+};
+
+export default WageData;
+
+const Td = styled.td`
+  text-align: left;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
+  min-width: 100px;
+`;

--- a/src/components/units/user/attendances/attendances.container.tsx
+++ b/src/components/units/user/attendances/attendances.container.tsx
@@ -1,6 +1,16 @@
+import { useLazyQuery } from '@apollo/client';
+import {
+  IQuery,
+  IQueryFetchMemberWorkChecksArgs,
+} from '../../../../commons/types/generated/types';
 import AttendancesPresenter from './attendances.presenter';
+import { FETCH_MEMBER_WORK_CHECKS } from './attendances.queries';
 
 const AttendancesContainer = () => {
+  const [getMemberWorkChecks, { data }] = useLazyQuery<
+    Pick<IQuery, 'fetchMemberWorkChecks'>,
+    IQueryFetchMemberWorkChecksArgs
+  >(FETCH_MEMBER_WORK_CHECKS);
   return <AttendancesPresenter />;
 };
 export default AttendancesContainer;

--- a/src/components/units/user/attendances/attendances.presenter.tsx
+++ b/src/components/units/user/attendances/attendances.presenter.tsx
@@ -11,6 +11,7 @@ const AttendancesPresenter = (props: IUserAttenancesProps) => {
           <li>근무시간</li>
           <li>근무일정</li>
           <li>조직</li>
+          <li>직무</li>
           <li>근무노트</li>
           <li>휴게시간</li>
           <li>총 시간</li>

--- a/src/components/units/user/attendances/attendances.queries.ts
+++ b/src/components/units/user/attendances/attendances.queries.ts
@@ -1,0 +1,27 @@
+import { gql } from '@apollo/client';
+
+export const FETCH_MEMBER_WORK_CHECKS = gql`
+  query fetchMemberWorkChecks($startDate: DateTIme!, $endDate: DateTime!) {
+    fetchMemberWorkChecks(startDate: $startDate, endDate: $endDate) {
+      id
+      workDay
+      workingTime
+      quittingTime
+      workCheckMemo
+      isConfirmed
+      createdAt
+      member {
+        id
+        name
+      }
+      organization {
+        id
+        name
+      }
+      roleCategory {
+        id
+        name
+      }
+    }
+  }
+`;

--- a/src/components/units/user/attendances/attendances.styles.ts
+++ b/src/components/units/user/attendances/attendances.styles.ts
@@ -2,7 +2,8 @@ import styled from '@emotion/styled';
 import { styleSet } from '../../../../commons/styles/styleSet';
 
 export const Container = styled.section`
-  max-width: 1270px;
+  /* max-width: 1270px; */
+  max-width: calc(100vw - 300px);
   overflow: auto;
 `;
 
@@ -17,6 +18,7 @@ export const Notice = styled.ul`
 
   li {
     min-width: 100px;
+    flex: 0;
   }
 `;
 


### PR DESCRIPTION
## 메인 변경 사항

- 근무일정 유형/템플릿, 휴가 유형, 근로정보 fetch API 연결. 
(현재 **근무일정 유형을 제외한 나머지는** 백엔드 api 개발 중인 이유로 **data fetch 이루어지지 않음.**)
---
### 추가 변경 사항
휴가 유형 leave-types -> vacation-category 로 이름 변경.
근무일정 유형 shift-types -> schedule-category 로 이름 변경.
근무일정 템플릿 shift-template -> schedule-template 로 이름 변경.

백엔드 DB 컬럼명 변경에 따른 roleCategory.duty -> name으로 변경.

closed #216