### PR TITLE
:sparkles: (adminManageScheduleCategory): FEATURE: 어드민 관리(근무일정 유형) cr…

### DIFF
--- a/src/components/commons/button/btn01.tsx
+++ b/src/components/commons/button/btn01.tsx
@@ -59,7 +59,7 @@ const Btn = styled.button`
     ${(Props: IStyleProps) => (Props.bdC ? Props.bdC : '#000')};
   border-radius: 2px;
   cursor: ${(Props: IStyleProps) =>
-    Props.disabledStatus ? 'help' : 'pointer'};
+    Props.disabledStatus ? 'auto' : 'pointer'};
 
   :hover {
     color: ${(Props: IStyleProps) =>

--- a/src/components/units/admin/manage/formsInModal/common/footer.tsx
+++ b/src/components/units/admin/manage/formsInModal/common/footer.tsx
@@ -7,6 +7,7 @@ interface IFooterProps {
   onCancel: () => void;
   isEdit?: boolean;
   onSoftDelete?: () => void;
+  isValid?: boolean;
 }
 
 const Footer = (props: IFooterProps) => {
@@ -36,7 +37,8 @@ const Footer = (props: IFooterProps) => {
             text={props.isEdit ? '수정하기' : '추가하기'}
             color="#fff"
             bgC={styleSet.colors.primary}
-            bdC={styleSet.colors.primary}
+            bdC={props.isValid ? styleSet.colors.primary : styleSet.colors.gray}
+            disabled={!props.isValid}
           />
         </ButtonBox>
       </Wrapper>

--- a/src/components/units/admin/manage/formsInModal/index.tsx
+++ b/src/components/units/admin/manage/formsInModal/index.tsx
@@ -3,16 +3,17 @@ import LeaveTypes from './leaveTypes';
 import Wages from './wages';
 import OrganizationFormContainer from './oraganization/organizationForm.container';
 import ScheduleTemplate from './scheduleTemplate';
-import ScheduleCategory from './scheduleCategory';
 import MemberFormContainer from './member/memberForm.container';
 import RoleCategoryFormContainer from './roleCategory/roleCategoryForm.container';
+import ScheduleCategoryFormContainer from './scheduleCategory/scheduleCategoryForm.container';
 
 const Form = (props: IFormProps) => {
   if (props.tab === '직원') return <MemberFormContainer {...props} />;
   if (props.tab === '지점') return <OrganizationFormContainer {...props} />;
   if (props.tab === '직무') return <RoleCategoryFormContainer {...props} />;
   if (props.tab === '근로 정보') return <Wages {...props} />;
-  if (props.tab === '근무일정 유형') return <ScheduleCategory {...props} />;
+  if (props.tab === '근무일정 유형')
+    return <ScheduleCategoryFormContainer {...props} />;
   if (props.tab === '근무일정 템플릿') return <ScheduleTemplate {...props} />;
   if (props.tab === '휴가 유형') return <LeaveTypes {...props} />;
   return <MemberFormContainer {...props} />;

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.container.tsx
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.container.tsx
@@ -1,0 +1,64 @@
+import { useMutation } from '@apollo/client';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import {
+  IMutation,
+  IMutationCreateScheduleCategoryArgs,
+} from '../../../../../../commons/types/generated/types';
+import { IFormProps } from '../common/form.types';
+import ScheduleCategoryFormPresenter from './scheduleCategoryForm.presenter';
+import { CREATE_SCHEDULE_CATEGORY } from './scheduleCategoryForm.queries';
+import { IFormData } from './scheduleCategoryForm.types';
+import * as yup from 'yup';
+
+const categoryFormSchema = yup.object({
+  name: yup.string().min(1).required(),
+});
+
+const ScheduleCategoryFormContainer = (props: IFormProps) => {
+  const [createScheduleCategory] = useMutation<
+    Pick<IMutation, 'createScheduleCategory'>,
+    IMutationCreateScheduleCategoryArgs
+  >(CREATE_SCHEDULE_CATEGORY);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid },
+  } = useForm<IFormData>({
+    resolver: yupResolver(categoryFormSchema),
+  });
+
+  const onSubmit = async (data: IFormData) => {
+    console.log(data);
+    if (!data.name) return;
+    try {
+      await createScheduleCategory({
+        variables: { createScheduleCategoryInput: data },
+        update(cache, { data }) {
+          cache.modify({
+            fields: {
+              fetchAllScheduleCategories: (prev) => {
+                return [data?.createScheduleCategory, ...prev];
+              },
+            },
+          });
+        },
+      });
+      props.onCancel();
+    } catch (error) {
+      alert(error as string);
+    }
+  };
+  return (
+    <ScheduleCategoryFormPresenter
+      isValid={isValid}
+      register={register}
+      handleSubmit={handleSubmit}
+      onSubmit={onSubmit}
+      onCancel={props.onCancel}
+    />
+  );
+};
+
+export default ScheduleCategoryFormContainer;

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.presenter.tsx
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.presenter.tsx
@@ -1,17 +1,19 @@
-import styled from '@emotion/styled';
 import { Divider } from 'antd';
-import Check01 from '../../../../commons/input/check01';
-import Footer from './common/footer';
-import { IFormProps } from './common/form.types';
-import InputLabel from './common/inputLabel';
-import Memo from './common/memo';
+import Check01 from '../../../../../commons/input/check01';
+import Footer from '../common/footer';
+import InputLabel from '../common/inputLabel';
+import Memo from '../common/memo';
+import { IScheduleCategoryFormPresenterProps } from './scheduleCategoryForm.types';
+import { Wrapper } from './scheduleCategoryForm.styles';
 
-const ScheduleCategory = (props: IFormProps) => {
+const ScheduleCategoryFormPresenter = (
+  props: IScheduleCategoryFormPresenterProps,
+) => {
   return (
     <form onSubmit={props.handleSubmit(props.onSubmit)}>
       <Wrapper>
         <InputLabel
-          register={props.register('shiftTypesName')}
+          register={props.register('name')}
           name="shiftTypesName"
           labelWidth="6.5rem"
           type="text"
@@ -30,24 +32,17 @@ const ScheduleCategory = (props: IFormProps) => {
         <Divider style={{ margin: '0' }} />
         <Check01
           text="연장근무일정 여부"
-          register={props.register('isOvertimeSchedule')}
+          register={props.register('isOvertime')}
         />
         <Check01
           text="휴일근무 미적용 여부"
-          register={props.register('isUnappliedHolidayWork')}
+          register={props.register('isNotHolidayWork')}
         />
         <Memo textareaHeight="5rem" register={props.register('memo')} />
       </Wrapper>
-      <Footer onCancel={props.onCancel} />
+      <Footer isValid={props.isValid} onCancel={props.onCancel} />
     </form>
   );
 };
 
-export default ScheduleCategory;
-
-const Wrapper = styled.div`
-  width: 30rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-`;
+export default ScheduleCategoryFormPresenter;

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.queries.ts
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.queries.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const CREATE_SCHEDULE_CATEGORY = gql`
+  mutation createScheduleCategory(
+    $createScheduleCategoryInput: CreateScheduleCategoryInput!
+  ) {
+    createScheduleCategory(
+      createScheduleCategoryInput: $createScheduleCategoryInput
+    ) {
+      id
+    }
+  }
+`;

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.styles.ts
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.styles.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  width: 30rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;

--- a/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.types.ts
+++ b/src/components/units/admin/manage/formsInModal/scheduleCategory/scheduleCategoryForm.types.ts
@@ -1,0 +1,22 @@
+import {
+  SubmitHandler,
+  UseFormHandleSubmit,
+  UseFormRegister,
+} from 'react-hook-form';
+
+export interface IFormData {
+  test: string;
+  name: string;
+  color: string;
+  isOvertime: boolean;
+  isNotHolidayWork: boolean;
+  memo?: string;
+}
+
+export interface IScheduleCategoryFormPresenterProps {
+  register: UseFormRegister<IFormData>;
+  onSubmit: SubmitHandler<IFormData>;
+  handleSubmit: UseFormHandleSubmit<IFormData>;
+  onCancel: () => void;
+  isValid: boolean;
+}


### PR DESCRIPTION
## 메인 변경 사항
  - 기존의 form인 scheduleCategory.tsx 삭제
  - 근무일정 유형 form 폴더 생성 후 근무일정 유형 form container/presenter 패턴 적용
  - 근무일정 유형 create API 연결
  - 근무일정 유형 form에 yup 도입 후 동적 유효성 검사 추가 (버튼 비활성화/활성화)
---
### 추가 변경 사항
  - btn01 disabled 상태에서의 hover 커서 변경

closed #266