### PR TITLE
:recycle: (refactoring): REF: 불필요한 코드 수정 및 제거

### DIFF
--- a/src/components/commons/input/select01.tsx
+++ b/src/components/commons/input/select01.tsx
@@ -126,7 +126,7 @@ const Select01 = (props: ISelectProps) => {
       props.setValue?.(
         props.name,
         props.singleMode
-          ? checkedList[0].id
+          ? checkedList[0]?.id
           : checkedList.map((el) => (props.returnNameMode ? el.name : el.id)),
       );
     } else props.setState?.(checkedList);

--- a/src/components/commons/switch/switch01.tsx
+++ b/src/components/commons/switch/switch01.tsx
@@ -44,7 +44,7 @@ const Switch01 = (props: ISwitch01Props) => {
 
 export default Switch01;
 
-const Switch = styled.li`
+const Switch = styled.span`
   display: flex;
   word-break: keep-all;
   align-items: center;

--- a/src/components/units/admin/manage/formsInModal/common/form.types.ts
+++ b/src/components/units/admin/manage/formsInModal/common/form.types.ts
@@ -11,10 +11,4 @@ export interface IFormProps {
     workInfos?: Pick<IQuery, 'fetchWorkInfos'>;
     scheduleCategories?: Pick<IQuery, 'fetchAllScheduleCategories'>;
   };
-
-  // 빌드 에러 수정용... 나중에 삭제
-  register?: any;
-  onSubmit?: any;
-  handleSubmit?: any;
-  setValue?: any;
 }

--- a/src/components/units/admin/manage/formsInModal/member/memberForm.presenter.tsx
+++ b/src/components/units/admin/manage/formsInModal/member/memberForm.presenter.tsx
@@ -70,6 +70,7 @@ const MemberFormpresenter = (props: IMemberFormPresenterProps) => {
                 <S.InnerContent>
                   <Check01
                     onChange={() => props.setIsActiveStartDate((prev) => !prev)}
+                    checked={props.isActiveStartDate}
                     text="입사일"
                   />
                   {props.isActiveStartDate && (
@@ -156,6 +157,7 @@ const MemberFormpresenter = (props: IMemberFormPresenterProps) => {
               <Check01
                 onChange={() => props.setIsActiveWagesInput((prev) => !prev)}
                 text="근로 정보 입력"
+                checked={props.isActiveWagesInput}
               />
               {props.isActiveWagesInput && (
                 <>
@@ -164,6 +166,7 @@ const MemberFormpresenter = (props: IMemberFormPresenterProps) => {
                     name="workInfoId"
                     setValue={props.setValue}
                     register={props.register('workInfoId')}
+                    defaultChecked={props.workInfoDefaultValue}
                     data={props.workInfos}
                     singleMode
                     textFillMode
@@ -174,7 +177,10 @@ const MemberFormpresenter = (props: IMemberFormPresenterProps) => {
                     type="custom"
                     name="appliedFrom"
                     customInput={
-                      <DatePicker onChange={props.onChangeAppliedFrom} />
+                      <DatePicker
+                        defaultValue={props.defaultAppliedFrom}
+                        onChange={props.onChangeAppliedFrom}
+                      />
                     }
                   >
                     적용 시점

--- a/src/components/units/admin/manage/formsInModal/member/memberForm.types.ts
+++ b/src/components/units/admin/manage/formsInModal/member/memberForm.types.ts
@@ -34,16 +34,18 @@ export interface IMemberFormPresenterProps {
   organizations?: InputData[];
   roleCategoryDefaultValue?: InputData[];
   organizationDefaultValue?: InputData[];
+  workInfoDefaultValue?: InputData[];
   isActiveStartDate: boolean;
   setIsActiveStartDate: Dispatch<SetStateAction<boolean>>;
-  defaultJoinDate?: Dayjs;
   onChangeStartDate: DatePickerProps['onChange'];
   onChangeEndDate: DatePickerProps['onChange'];
   onChangeAppliedFrom: DatePickerProps['onChange'];
   onCancel: () => void;
   setIsActiveEndDate: Dispatch<SetStateAction<boolean>>;
   isActiveEndDate: boolean;
+  defaultJoinDate?: Dayjs;
   defaultExitDate?: Dayjs;
+  defaultAppliedFrom?: Dayjs;
   onChangeInvitation: (
     index: number,
   ) => (e: ChangeEvent<HTMLInputElement>) => void;

--- a/src/components/units/admin/manage/manageSidebar/index.tsx
+++ b/src/components/units/admin/manage/manageSidebar/index.tsx
@@ -6,10 +6,6 @@ interface ITabProps {
   isActive: boolean;
 }
 
-// interface IStyle {
-//   isAdminSidebar?: boolean;
-// }
-
 const ManageSidebarComponent = () => {
   const router = useRouter();
 
@@ -24,6 +20,7 @@ const ManageSidebarComponent = () => {
   ];
 
   const onClickChangeTab = (path: string) => async () => {
+    if (router.asPath.includes(path)) return;
     await router.push(`/admin/manage/${path}`);
   };
   return (

--- a/src/components/units/admin/profile/adminProfile.container.tsx
+++ b/src/components/units/admin/profile/adminProfile.container.tsx
@@ -1,7 +1,6 @@
 import { CheckCircleOutlined } from '@ant-design/icons';
 import { useMutation, useQuery } from '@apollo/client';
 import { notification } from 'antd';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { styleSet } from '../../../../commons/styles/styleSet';
 import {
@@ -21,8 +20,7 @@ const AdminProfile = () => {
     Pick<IMutation, 'changeAccount'>,
     IMutationChangeAccountArgs
   >(CHANGE_ACCOUNT);
-  const [categoryModalState, setCategoryModalState] = useState(false);
-  const [organizationModalState, setOrganizationModalState] = useState(false);
+
   const { register, handleSubmit, setValue } = useForm<IFormData>({});
 
   const onSubmit = async (data: IFormData) => {
@@ -51,24 +49,13 @@ const AdminProfile = () => {
     }
   };
 
-  const onClickToggleCategoryModal = () => {
-    setCategoryModalState((prev) => !prev);
-  };
-  const onClickToggleOrganizationModal = () => {
-    setOrganizationModalState((prev) => !prev);
-  };
-
   return (
     <AdminProfileUI
       data={accountData}
       setValue={setValue}
       onSubmit={onSubmit}
       handleSubmit={handleSubmit}
-      categoryModalState={categoryModalState}
-      organizationModalState={organizationModalState}
       register={register}
-      onClickToggleCategoryModal={onClickToggleCategoryModal}
-      onClickToggleOrganizationModal={onClickToggleOrganizationModal}
     />
   );
 };

--- a/src/components/units/admin/profile/adminProfile.presenter.tsx
+++ b/src/components/units/admin/profile/adminProfile.presenter.tsx
@@ -47,21 +47,22 @@ const AdminProfileUI = (props: IAdminProfileProps) => {
           <S.FormContents>
             <S.Label>직무들</S.Label>
             <Select01
-              // register={props.register('duty')}
-              // setValue={props.setValue}
               name={'duty'}
+              data={[
+                { id: 'busker', name: '직무A' },
+                { id: 'zero9', name: '직무B' },
+                { id: 'wetrekking', name: '직무C' },
+              ]}
             />
           </S.FormContents>
           <S.FormContents>
             <S.Label>지점들</S.Label>
             <Select01
-              // register={props.register('organization')}
-              // setValue={props.setValue}
               name={'oranization'}
               data={[
-                { id: 'busker', name: 'BUSKER' },
-                { id: 'zero9', name: 'ZERO9' },
-                { id: 'wetrekking', name: 'WETREKKING' },
+                { id: 'busker', name: '지점A' },
+                { id: 'zero9', name: '지점B' },
+                { id: 'wetrekking', name: '지점C' },
               ]}
             />
           </S.FormContents>

--- a/src/components/units/admin/profile/adminProfile.types.ts
+++ b/src/components/units/admin/profile/adminProfile.types.ts
@@ -19,8 +19,4 @@ export interface IAdminProfileProps {
   handleSubmit: UseFormHandleSubmit<IFormData>;
   data?: Pick<IQuery, 'fetchAccount'>;
   items?: MenuProps['items'];
-  organizationModalState: boolean;
-  categoryModalState: boolean;
-  onClickToggleOrganizationModal: () => void;
-  onClickToggleCategoryModal: () => void;
 }


### PR DESCRIPTION
- `li in li` 에러 없애기 위해 Switch01 `li` 태그를 `span` 태그로 변경
- 빌드 에러 방지용으로 작성해놓은 타입 삭제
- 근로정보를 가진 직원 수정 시, 근로정보가 기본값으로 뜨지 않던 문제 해결 및 updateMember & insertWorkInfo API 재연결
  - 기본값을 위해 사용할 변수(workInfoDefaultValue) 선언  => `dayjs` 타입으로 변환 => `DatePicker`의 기본값으로 설정
- 사용하지 않는 상태와 상태 핸들러, 타입 제거
- 불필요한 주석 제거

closed #310